### PR TITLE
Fix Android package configuration in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
       "supportsTablet": true
     },
     "android": {
+      "package": "com.llmchat.app",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"


### PR DESCRIPTION
- Add required 'android.package' property to resolve CommandError
- Enables proper Android development builds and testing
- Package name: com.llmchat.app